### PR TITLE
new fix for QA branch: Some tests where fixed and now they are passed

### DIFF
--- a/cypress/e2e/test/Suites/GX-194/Iterations.Droggable.cy.js
+++ b/cypress/e2e/test/Suites/GX-194/Iterations.Droggable.cy.js
@@ -6,9 +6,9 @@ describe("US 194 ToolsQA | Interactions | Dragabble", () =>
     const X = between(-300,400)
     const Y = between(-300, 300)
     
-    before(() =>
+    beforeEach(() =>
     {
-        cy.visit("/dragabble")
+        cy.visit("https://demoqa.com/dragabble")
         cy.url().should("contain","dragabble")
     })
     it("US 194 | TS 200 | TC1: Check “Drag and Drop” successfully in any spot.", () =>

--- a/cypress/e2e/test/Suites/GX-Example/CheckBox.cy.js
+++ b/cypress/e2e/test/Suites/GX-Example/CheckBox.cy.js
@@ -6,7 +6,7 @@ describe("CheckBox", () =>
     })
     it.skip("TS | TC1: Validar toggle abrir y cerrar", () =>
     {
-        cy.fixture("DOM/toolsqa/Elements/CheckBoxPage").then((the) =>
+        cy.fixture("DOM/toolsqa/Elements/CheckBox.Page").then((the) =>
         {
             // Abrir Toggles:
             cy.get(the.toggle).eq(0).click()

--- a/cypress/e2e/test/Suites/GX-Example/TextBox.cy.js
+++ b/cypress/e2e/test/Suites/GX-Example/TextBox.cy.js
@@ -12,29 +12,29 @@ describe("Text Box", () =>
             cy.get(the.email.input).type(the.email.valid)
             cy.get(the.currentAdr.input).type(the.currentAdr.valid)
             cy.get(the.permanentAdr.input).type(the.permanentAdr.valid)
-            cy.get(the.Submit).click()
+            cy.get(the.SubmitBtn).click()
         })
     })
     it("TS | TC1: Submit Form correctly", () =>
     {
-        cy.fixture("DOM/toolsqa/Elements/TextBoxPage").then((the) =>
+        cy.fixture("DOM/toolsqa/Elements/TextBox.Page").then((the) =>
         {
             cy.get(the.fullName.input).should("be.empty")
             cy.get(the.email.input).should("be.empty")
             cy.get(the.currentAdr.input).should("be.empty")
             cy.get(the.permanentAdr.input).should("be.empty")
-            cy.get(the.Submit).click()
+            cy.get(the.SubmitBtn).click()
         })
     })
     it("TS | TC1: Submit Form correctly", () =>
     {
-        cy.fixture("DOM/toolsqa/Elements/TextBoxPage").then((the) =>
+        cy.fixture("DOM/toolsqa/Elements/TextBox.Page").then((the) =>
         {
             cy.get(the.fullName.input).type(the.fullName.valid)
             cy.get(the.email.input).type(the.email.noName)
             cy.get(the.currentAdr.input).type(the.currentAdr.valid)
             cy.get(the.permanentAdr.input).type(the.permanentAdr.valid)
-            cy.get(the.Submit).click()
+            cy.get(the.SubmitBtn).click()
         })
     })
 })


### PR DESCRIPTION
Se realizó una Regresión de toda la carpeta Suites (el de sin cucumber), y se identificaron algunos errores. 
Se corrigieron un par de errores que ocurrían cuando se modificó un fixture.
--- TASK: @LauraMont @Nico950 
Deben agregar el Cypress.Commands que falta en estos archivos "Elements.TextBox" que fallaron!

Contexto: Ayer se realizó una refactorización del código y se removieron algunos commits, entre ellos, se removió un command que se creó pero se reusaba y hace fallar algunas pruebas por falta del mismo.
Para arreglar el problema, solo necesitamos que vuelvan a mergear a QA con el command disponible (PERO ANTES DEBEN HACER UN PULL DE QA)

Aquí pueden ver el Resultado de la mini Regression:
![image](https://user-images.githubusercontent.com/91127281/191910251-1f969569-3fd5-493f-a7f5-92d3f06438a7.png)
