### PR TITLE
Gx2 8176 book store grid actualizar y eliminar libros de la tienda put delete

### DIFF
--- a/.github/workflows/CI-Suite.yml
+++ b/.github/workflows/CI-Suite.yml
@@ -55,11 +55,7 @@ jobs:
               with:
                   browser: electron
                   command: | #EDITAR AQUÍ EL ARCHIVO SUITE A EJECUTAR:
-<<<<<<< HEAD
                       yarn file cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
-=======
-                      yarn file cypress/e2e/Tests/Forms/GX-34871-PracticeForm.cy.js
->>>>>>> 5b45cd73cd42a16e53754744210b37da8251a789
 
             - name: ✅Import Test Results to Xray
               if: always()
@@ -69,13 +65,8 @@ jobs:
                   password: ${{secrets.XRAY_CLIENT_SECRET}}
                   testFormat: 'junit' #OPCIONES PARA CAMBIAR: 'junit' (para xml) o 'cucumber' (para json)
                   testPaths: 'reports/test-results.xml' #OPCIONES: '/test-results.xml' o 'cucumber-report.json'
-<<<<<<< HEAD
                   testExecKey: 'GX2-8178' #EDITAR AQUÍ EL TEST EXECUTION A IMPORTAR LAS PRUEBAS.
                   projectKey: 'GX2' #EDITAR EN CASO DE TRABAJAR CON OTRO PROYECTO.
-=======
-                  testExecKey: 'GX-34873' #EDITAR AQUÍ EL TEST EXECUTION A IMPORTAR LAS PRUEBAS.
-                  projectKey: 'GX' #EDITAR EN CASO DE TRABAJAR CON OTRO PROYECTO.
->>>>>>> 5b45cd73cd42a16e53754744210b37da8251a789
 
             - name: 🔔Slack Notification of Done
               if: always()

--- a/.github/workflows/CI-Suite.yml
+++ b/.github/workflows/CI-Suite.yml
@@ -55,7 +55,7 @@ jobs:
               with:
                   browser: electron
                   command: | #EDITAR AQUÍ EL ARCHIVO SUITE A EJECUTAR:
-                      yarn file cypress/e2e/Tests/Elements/GX-38056-Buttons.cy.js
+                      yarn file cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
 
             - name: ✅Import Test Results to Xray
               if: always()
@@ -65,9 +65,8 @@ jobs:
                   password: ${{secrets.XRAY_CLIENT_SECRET}}
                   testFormat: 'junit' #OPCIONES PARA CAMBIAR: 'junit' (para xml) o 'cucumber' (para json)
                   testPaths: 'reports/test-results.xml' #OPCIONES: '/test-results.xml' o 'cucumber-report.json'
-                  testExecKey: 'GX-38058' #EDITAR AQUÍ EL TEST EXECUTION A IMPORTAR LAS PRUEBAS.
-                  projectKey: 'GX' #EDITAR EN CASO DE TRABAJAR CON OTRO PROYECTO.
-
+                  testExecKey: 'GX2-8178' #EDITAR AQUÍ EL TEST EXECUTION A IMPORTAR LAS PRUEBAS.
+                  projectKey: 'GX2' #EDITAR EN CASO DE TRABAJAR CON OTRO PROYECTO.
 
             - name: 🔔Slack Notification of Done
               if: always()

--- a/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
+++ b/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
@@ -1,0 +1,5 @@
+describe('BookStore | Grid | Actualizar y Eliminar Libros de la Tienda (PUT-DELETE)', () => {
+	beforeEach('PCR: Situarse en la Web , Loguearse correctamente , add 1 o más productos', () => {
+		cy.visit('/login');
+	});
+});

--- a/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
+++ b/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
@@ -43,7 +43,22 @@ describe('BookStore | Grid | Actualizar y Eliminar Libros de la Tienda (PUT-DELE
 		BookStorePage.deleteBook({ isbn: data.idBook1, userId: '' }).then(response => {
 			expect(response.status).to.eq(401);
 			expect(response.statusText).to.equal('Unauthorized');
-			expect(response.body.message).to.contain(data.emptyId);
+			expect(response.body.message).to.contain(data.emptyIdOrInexistent);
+		});
+	});
+	it('8177 | TC7: (DELETE) Validar NO remover todos los producto del profile con “userId” vacio', () => {
+		BookStorePage.deleteAllBooks({ userId: '' }).then(response => {
+			expect(response.status).to.eq(401);
+			expect(response.statusText).to.equal('Unauthorized');
+			expect(response.body.message).to.contain(data.emptyIdOrInexistent);
+		});
+	});
+
+	it('8177 | TC8: (DELETE) Validar NO remover todos los producto del profile con “userId” inexistente', () => {
+		BookStorePage.deleteAllBooks({ userId: data.UserIDInexistent }).then(response => {
+			expect(response.status).to.eq(401);
+			expect(response.statusText).to.equal('Unauthorized');
+			expect(response.body.message).to.contain(data.emptyIdOrInexistent);
 		});
 	});
 });

--- a/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
+++ b/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
@@ -13,6 +13,9 @@ const initialSetup = () => {
 		expect(response3.body.books[1].isbn).to.equal(Cypress.env('book2'));
 	});
 };
+const preconditionDeleteAllBooks = () => {
+	BookStorePage.deleteAllBooks({ userId: data.userID });
+};
 
 describe('BookStore | Grid | Actualizar y Eliminar Libros de la Tienda (PUT-DELETE)', () => {
 	beforeEach('precondition', () => {
@@ -36,21 +39,21 @@ describe('BookStore | Grid | Actualizar y Eliminar Libros de la Tienda (PUT-DELE
 		BookStorePage.deleteBook({ isbn: '', userId: data.userID }).then(response => {
 			expect(response.status).to.eq(400);
 			expect(response.statusText).to.equal('Bad Request');
-			expect(response.body.message).to.include(data.emptyIsbn);
+			expect(response.body.message).to.include(data.messageEmptyIsbn);
 		});
 	});
 	it('8177 | TC6: (DELETE) Validar NO remover un producto del profile con “userId” vacio', () => {
 		BookStorePage.deleteBook({ isbn: data.idBook1, userId: '' }).then(response => {
 			expect(response.status).to.eq(401);
 			expect(response.statusText).to.equal('Unauthorized');
-			expect(response.body.message).to.contain(data.emptyIdOrInexistent);
+			expect(response.body.message).to.contain(data.messageEmptyIdOrInexistent);
 		});
 	});
 	it('8177 | TC7: (DELETE) Validar NO remover todos los producto del profile con “userId” vacio', () => {
 		BookStorePage.deleteAllBooks({ userId: '' }).then(response => {
 			expect(response.status).to.eq(401);
 			expect(response.statusText).to.equal('Unauthorized');
-			expect(response.body.message).to.contain(data.emptyIdOrInexistent);
+			expect(response.body.message).to.contain(data.messageEmptyIdOrInexistent);
 		});
 	});
 
@@ -58,7 +61,24 @@ describe('BookStore | Grid | Actualizar y Eliminar Libros de la Tienda (PUT-DELE
 		BookStorePage.deleteAllBooks({ userId: data.UserIDInexistent }).then(response => {
 			expect(response.status).to.eq(401);
 			expect(response.statusText).to.equal('Unauthorized');
-			expect(response.body.message).to.contain(data.emptyIdOrInexistent);
+			expect(response.body.message).to.contain(data.messageEmptyIdOrInexistent);
+		});
+	});
+	it('8177 | TC9: (PUT) Validar actualizar un libro/producto del profile', () => {
+		preconditionDeleteAllBooks();
+		initialSetup();
+		BookStorePage.replaceBookISBN({ NewIsbn: data.idBook3, userId: data.userID, ToReplaceIsbn: data.idBook1 }).then(response => {
+			expect(response.status).to.eq(200);
+			expect(response.body.books[1].isbn).to.contain(data.idBook3);
+		});
+	});
+	it('8177 | TC10: (PUT) Validar NO actualizar un libro/producto del profile con “isbn” vacio', () => {
+		preconditionDeleteAllBooks();
+		initialSetup();
+		BookStorePage.replaceBookISBN({ NewIsbn: '', userId: data.userID, ToReplaceIsbn: data.idBook1 }).then(response => {
+			expect(response.status).to.eq(400);
+			expect(response.statusText).to.equal('Bad Request');
+			expect(response.body.message).to.contain(data.messageEmptyIdOrIsbnPUTmethod);
 		});
 	});
 });

--- a/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
+++ b/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
@@ -1,5 +1,23 @@
-describe('BookStore | Grid | Actualizar y Eliminar Libros de la Tienda (PUT-DELETE)', () => {
-	beforeEach('PCR: Situarse en la Web , Loguearse correctamente , add 1 o más productos', () => {
-		cy.visit('/login');
+//TC Cancelado debido a problemas del sitoWeb
+//8177 | TC1: Validar remover producto utilizando el icono "TrashCan"
+//8177 | TC2: Validar remover todos los productos utilizando el boton "Delete All Books".
+import data from '../../../fixtures/data/GX2-8176-Bookstore-put-delete.json';
+import { BookStorePage } from '@pages/BookStore/GX2-8176-Bookstore-put-delete';
+const initialSetup = () => {
+	BookStorePage.Precondition().then(([response1, response2, response3]) => {
+		expect(response1.status).to.eq(200);
+		expect(response2.status).to.eq(200);
+		expect(response3.status).to.eq(201);
+		expect(response2.body).to.eq(true);
+		expect(response3.body.books[0].isbn).to.equal(Cypress.env('book1'));
+		expect(response3.body.books[1].isbn).to.equal(Cypress.env('book2'));
 	});
+};
+
+describe('BookStore | Grid | Actualizar y Eliminar Libros de la Tienda (PUT-DELETE)', () => {
+	beforeEach('precondition', () => {
+		initialSetup();
+	});
+
+	it('TC3: (DELETE) Validar remover un producto del profile', () => {});
 });

--- a/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
+++ b/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
@@ -25,4 +25,11 @@ describe('BookStore | Grid | Actualizar y Eliminar Libros de la Tienda (PUT-DELE
 			expect(response.statusText).to.equal('No Content');
 		});
 	});
+
+	it('8177 | TC4: (DELETE) Validar remover todos los producto del profile', () => {
+		BookStorePage.deleteAllBooks({ userId: data.userID }).then(response => {
+			expect(response.status).to.eq(204);
+			expect(response.statusText).to.equal('No Content');
+		});
+	});
 });

--- a/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
+++ b/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
@@ -22,7 +22,7 @@ describe('BookStore | Grid | Actualizar y Eliminar Libros de la Tienda (PUT-DELE
 		initialSetup();
 	});
 
-	it('TC3: (DELETE) Validar remover un producto del profile', () => {
+	it('8177 | TC3: (DELETE) Validar remover un producto del profile', () => {
 		BookStorePage.deleteBook({ isbn: data.idBook1, userId: data.userID }).then(response => {
 			expect(response.status).to.eq(204);
 			expect(response.statusText).to.equal('No Content');

--- a/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
+++ b/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
@@ -39,7 +39,7 @@ describe('BookStore | Grid | Actualizar y Eliminar Libros de la Tienda (PUT-DELE
 		BookStorePage.deleteBook({ isbn: '', userId: data.userID }).then(response => {
 			expect(response.status).to.eq(400);
 			expect(response.statusText).to.equal('Bad Request');
-			expect(response.body.message).to.include(data.messageEmptyIsbn);
+			expect(response.body.message).to.include(data.messageEmptyIsbnOrInexistent);
 		});
 	});
 	it('8177 | TC6: (DELETE) Validar NO remover un producto del profile con “userId” vacio', () => {
@@ -79,6 +79,24 @@ describe('BookStore | Grid | Actualizar y Eliminar Libros de la Tienda (PUT-DELE
 			expect(response.status).to.eq(400);
 			expect(response.statusText).to.equal('Bad Request');
 			expect(response.body.message).to.contain(data.messageEmptyIdOrIsbnPUTmethod);
+		});
+	});
+	it('8177 | TC11: (PUT) Validar NO actualizar un libro/producto del profile con “isbn” inexistente', () => {
+		preconditionDeleteAllBooks();
+		initialSetup();
+		BookStorePage.replaceBookISBN({ NewIsbn: data.isbnInexistent, userId: data.userID, ToReplaceIsbn: data.idBook1 }).then(response => {
+			expect(response.status).to.eq(400);
+			expect(response.statusText).to.equal('Bad Request');
+			expect(response.body.message).to.contain(data.messageEmptyIsbnOrInexistent);
+		});
+	});
+	it('8177 | TC12: (PUT) Validar NO actualizar un libro/producto del profile con “userId” inexistente', () => {
+		preconditionDeleteAllBooks();
+		initialSetup();
+		BookStorePage.replaceBookISBN({ NewIsbn: data.idBook3, userId: data.UserIDInexistent, ToReplaceIsbn: data.idBook1 }).then(response => {
+			expect(response.status).to.eq(401);
+			expect(response.statusText).to.equal('Unauthorized');
+			expect(response.body.message).to.contain(data.messageEmptyIdOrInexistent);
 		});
 	});
 });

--- a/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
+++ b/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
@@ -4,7 +4,7 @@
 import data from '../../../fixtures/data/GX2-8176-Bookstore-put-delete.json';
 import { BookStorePage } from '@pages/BookStore/GX2-8176-Bookstore-put-delete';
 const initialSetup = () => {
-	BookStorePage.Precondition().then(([response1, response2, response3]) => {
+	BookStorePage.precondition().then(([response1, response2, response3]) => {
 		expect(response1.status).to.eq(200);
 		expect(response2.status).to.eq(200);
 		expect(response3.status).to.eq(201);
@@ -19,5 +19,10 @@ describe('BookStore | Grid | Actualizar y Eliminar Libros de la Tienda (PUT-DELE
 		initialSetup();
 	});
 
-	it('TC3: (DELETE) Validar remover un producto del profile', () => {});
+	it('TC3: (DELETE) Validar remover un producto del profile', () => {
+		BookStorePage.deleteBook({ isbn: data.idBook1, userId: data.userID }).then(response => {
+			expect(response.status).to.eq(204);
+			expect(response.statusText).to.equal('No Content');
+		});
+	});
 });

--- a/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
+++ b/cypress/e2e/Tests/BookStore/GX2-8176-Put-Delete.cy.js
@@ -32,4 +32,18 @@ describe('BookStore | Grid | Actualizar y Eliminar Libros de la Tienda (PUT-DELE
 			expect(response.statusText).to.equal('No Content');
 		});
 	});
+	it('8177 | TC5: (DELETE) Validar NO remover un producto del profile con “isbn” vacio', () => {
+		BookStorePage.deleteBook({ isbn: '', userId: data.userID }).then(response => {
+			expect(response.status).to.eq(400);
+			expect(response.statusText).to.equal('Bad Request');
+			expect(response.body.message).to.include(data.emptyIsbn);
+		});
+	});
+	it('8177 | TC6: (DELETE) Validar NO remover un producto del profile con “userId” vacio', () => {
+		BookStorePage.deleteBook({ isbn: data.idBook1, userId: '' }).then(response => {
+			expect(response.status).to.eq(401);
+			expect(response.statusText).to.equal('Unauthorized');
+			expect(response.body.message).to.contain(data.emptyId);
+		});
+	});
 });

--- a/cypress/fixtures/data/GX2-8176-Bookstore-put-delete.json
+++ b/cypress/fixtures/data/GX2-8176-Bookstore-put-delete.json
@@ -8,8 +8,9 @@
 	"username": "Lazzeration",
 	"password": "Lazzeration123%",
 	"userID": "1dcf8d6d-4f0b-4704-87d4-537eba179b7a",
+	"UserIDInexistent": "787dfd4f-5ddd-6442-s7$7-a#e64$56ff6s",
 	"idBook1": "9781593275846",
 	"idBook2": "9781491950296",
 	"emptyIsbn": "ISBN supplied is not available",
-	"emptyId": "User Id not correct!"
+	"emptyIdOrInexistent": "User Id not correct!"
 }

--- a/cypress/fixtures/data/GX2-8176-Bookstore-put-delete.json
+++ b/cypress/fixtures/data/GX2-8176-Bookstore-put-delete.json
@@ -9,5 +9,7 @@
 	"password": "Lazzeration123%",
 	"userID": "1dcf8d6d-4f0b-4704-87d4-537eba179b7a",
 	"idBook1": "9781593275846",
-	"idBook2": "9781491950296"
+	"idBook2": "9781491950296",
+	"emptyIsbn": "ISBN supplied is not available",
+	"emptyId": "User Id not correct!"
 }

--- a/cypress/fixtures/data/GX2-8176-Bookstore-put-delete.json
+++ b/cypress/fixtures/data/GX2-8176-Bookstore-put-delete.json
@@ -1,0 +1,13 @@
+{
+	"dom": "https://demoqa.com",
+	"endpoints": {
+		"profile": "/profile",
+		"login": "/login"
+	},
+
+	"username": "Lazzeration",
+	"password": "Lazzeration123%",
+	"userID": "1dcf8d6d-4f0b-4704-87d4-537eba179b7a",
+	"idBook1": "9781593275846",
+	"idBook2": "9781491950296"
+}

--- a/cypress/fixtures/data/GX2-8176-Bookstore-put-delete.json
+++ b/cypress/fixtures/data/GX2-8176-Bookstore-put-delete.json
@@ -12,7 +12,8 @@
 	"idBook1": "9781593275846",
 	"idBook2": "9781491950296",
 	"idBook3": "9781593277574",
-	"messageEmptyIsbn": "ISBN supplied is not available",
+	"isbnInexistent": "9777225555553",
+	"messageEmptyIsbnOrInexistent": "ISBN supplied is not available",
 	"messageEmptyIdOrInexistent": "User Id not correct!",
 	"messageEmptyIdOrIsbnPUTmethod": "Request Body is Invalid!"
 }

--- a/cypress/fixtures/data/GX2-8176-Bookstore-put-delete.json
+++ b/cypress/fixtures/data/GX2-8176-Bookstore-put-delete.json
@@ -11,6 +11,8 @@
 	"UserIDInexistent": "787dfd4f-5ddd-6442-s7$7-a#e64$56ff6s",
 	"idBook1": "9781593275846",
 	"idBook2": "9781491950296",
-	"emptyIsbn": "ISBN supplied is not available",
-	"emptyIdOrInexistent": "User Id not correct!"
+	"idBook3": "9781593277574",
+	"messageEmptyIsbn": "ISBN supplied is not available",
+	"messageEmptyIdOrInexistent": "User Id not correct!",
+	"messageEmptyIdOrIsbnPUTmethod": "Request Body is Invalid!"
 }

--- a/cypress/fixtures/data/GX2-8176.json
+++ b/cypress/fixtures/data/GX2-8176.json
@@ -1,0 +1,9 @@
+{
+	"endpoints": {
+		"profile": "/profile",
+		"login": "/login"
+	},
+
+	"username": "Lazzeration",
+	"password": "Lazzeration123%"
+}

--- a/cypress/fixtures/data/GX2-8176.json
+++ b/cypress/fixtures/data/GX2-8176.json
@@ -1,9 +1,0 @@
-{
-	"endpoints": {
-		"profile": "/profile",
-		"login": "/login"
-	},
-
-	"username": "Lazzeration",
-	"password": "Lazzeration123%"
-}

--- a/cypress/support/pages/BookStore/GX2-8176-Bookstore-put-delete.js
+++ b/cypress/support/pages/BookStore/GX2-8176-Bookstore-put-delete.js
@@ -1,7 +1,7 @@
 import data from '../../../fixtures/data/GX2-8176-Bookstore-put-delete.json';
 let response1, response2, response3;
 class BookStore {
-	Precondition() {
+	precondition() {
 		return cy
 			.api({
 				failOnStatusCode: false,
@@ -52,6 +52,26 @@ class BookStore {
 				Cypress.env('book1', response.body.books[0].isbn);
 				Cypress.env('book2', response.body.books[1].isbn);
 				return [response1, response2, response3];
+			});
+	}
+
+	deleteBook({ isbn: isbn = '', userId: userId = '' }) {
+		return cy
+			.api({
+				failOnStatusCode: false,
+				method: 'DELETE',
+				url: `${data.dom}/BookStore/v1/Book`,
+				auth: {
+					username: data.username,
+					password: data.password,
+				},
+				body: {
+					isbn: isbn == '' ? '' : isbn,
+					userId: userId == '' ? '' : userId,
+				},
+			})
+			.then(response => {
+				return response;
 			});
 	}
 }

--- a/cypress/support/pages/BookStore/GX2-8176-Bookstore-put-delete.js
+++ b/cypress/support/pages/BookStore/GX2-8176-Bookstore-put-delete.js
@@ -13,7 +13,7 @@ class BookStore {
 				},
 			})
 			.then(response => {
-				Cypress.env('token', response.token);
+				Cypress.env('token', response.body.token);
 				response1 = response;
 				return cy.api({
 					failOnStatusCode: false,
@@ -68,6 +68,24 @@ class BookStore {
 				body: {
 					isbn: isbn == '' ? '' : isbn,
 					userId: userId == '' ? '' : userId,
+				},
+			})
+			.then(response => {
+				return response;
+			});
+	}
+
+	deleteAllBooks({ userId = '' }) {
+		userId = userId == '' ? '' : userId;
+
+		return cy
+			.api({
+				failOnStatusCode: false,
+				method: 'DELETE',
+				url: `${data.dom}/BookStore/v1/Books?UserId=${userId}`,
+				auth: {
+					username: data.username,
+					password: data.password,
 				},
 			})
 			.then(response => {

--- a/cypress/support/pages/BookStore/GX2-8176-Bookstore-put-delete.js
+++ b/cypress/support/pages/BookStore/GX2-8176-Bookstore-put-delete.js
@@ -1,0 +1,59 @@
+import data from '../../../fixtures/data/GX2-8176-Bookstore-put-delete.json';
+let response1, response2, response3;
+class BookStore {
+	Precondition() {
+		return cy
+			.api({
+				failOnStatusCode: false,
+				method: 'POST',
+				url: `${data.dom}/Account/v1/GenerateToken`,
+				body: {
+					userName: data.username,
+					password: data.password,
+				},
+			})
+			.then(response => {
+				Cypress.env('token', response.token);
+				response1 = response;
+				return cy.api({
+					failOnStatusCode: false,
+					method: 'POST',
+					url: `${data.dom}/Account/v1/Authorized`,
+					body: {
+						userName: data.username,
+						password: data.password,
+					},
+				});
+			})
+			.then(response => {
+				response2 = response;
+				return cy.api({
+					method: 'POST',
+					url: `${data.dom}/BookStore/v1/Books`,
+					auth: {
+						username: data.username,
+						password: data.password,
+					},
+					body: {
+						userId: data.userID,
+						collectionOfIsbns: [
+							{
+								isbn: data.idBook1,
+							},
+							{
+								isbn: data.idBook2,
+							},
+						],
+					},
+				});
+			})
+			.then(response => {
+				response3 = response;
+				Cypress.env('book1', response.body.books[0].isbn);
+				Cypress.env('book2', response.body.books[1].isbn);
+				return [response1, response2, response3];
+			});
+	}
+}
+
+export const BookStorePage = new BookStore();

--- a/cypress/support/pages/BookStore/GX2-8176-Bookstore-put-delete.js
+++ b/cypress/support/pages/BookStore/GX2-8176-Bookstore-put-delete.js
@@ -92,6 +92,25 @@ class BookStore {
 				return response;
 			});
 	}
+	replaceBookISBN({ NewIsbn: NewIsbn = '', userId: userId = '', ToReplaceIsbn: ToReplaceIsbn }) {
+		return cy
+			.api({
+				failOnStatusCode: false,
+				method: 'PUT',
+				url: `${data.dom}/BookStore/v1/Books/${ToReplaceIsbn}`,
+				auth: {
+					username: data.username,
+					password: data.password,
+				},
+				body: {
+					userId: userId == '' ? '' : userId,
+					isbn: NewIsbn == '' ? '' : NewIsbn,
+				},
+			})
+			.then(response => {
+				return response;
+			});
+	}
 }
 
 export const BookStorePage = new BookStore();

--- a/cypress/support/pages/BookStore/GX2-8176-loginPage.js
+++ b/cypress/support/pages/BookStore/GX2-8176-loginPage.js
@@ -1,0 +1,15 @@
+class Login {
+	get = {
+		usernameInput: () => cy.get('#userName'),
+		passwordInput: () => cy.get('#password'),
+		loginButton: () => cy.get('#login'),
+	};
+
+	login({ username: username, password: password }) {
+		this.get.usernameInput().type(username);
+		this.get.passwordInput().type(password);
+		this.get.loginButton().click();
+	}
+}
+
+export const loginPage = new Login();

--- a/cypress/test-plan/in-sprint/sprint-28/GX2-8176.md
+++ b/cypress/test-plan/in-sprint/sprint-28/GX2-8176.md
@@ -1,0 +1,93 @@
+🚩BUSINESS RULES SPEC
+
+Precondición: (OOS) Como precondición hay que estar logeado en el SUT, para ello hay que crearse un usuario desde: El registro o el Backend:
+
+FRONTEND: (Register)
+
+BACKEND:POST/Account/v1/User
+
+Body: RegisterViewModel
+
+{ "userName": "string", "password": "string" } Para validar desde el BACKEND hay que tener autorización:
+
+POST /Account/v1/Authorized
+
+Body: LoginViewModel
+
+{ "userName": "string", "password": "string" } POST /Account/v1/GenerateToken
+
+Body: LoginViewModel
+
+{ "userName": "string", "password": "string" } BUSINESS RULES para la creación de usuario (OOS): Campos requeridos para la creación de usuario:
+
+First Name :
+
+Este campo no debe ser NULL:
+
+Si el campo es NULL:
+
+Desde el FRONTEND no se muestra mensaje PERO el campo se vuelve de color rojo.
+
+Este campo no aparece en el BACKEND.
+
+Este campo puede contener 1 o mas caracteres: alfanuméricos , caracteres especiales, mayúsculas o minúsculas
+
+Last Name :
+
+Este campo no debe ser NULL:
+
+Si el campo es NULL:
+
+Desde el FRONTEND no se muestra mensaje PERO el campo se vuelve de color rojo.
+
+Este campo no aparece en el BACKEND.
+
+Este campo puede contener 1 o mas caracteres: alfanuméricos , caracteres especiales, mayúsculas o minúsculas en todas sus combinaciones
+
+UserName :
+
+Este campo no debe ser NULL:
+
+Si el campo es NULL:
+
+Desde el FRONTEND no se muestra mensaje PERO el campo se vuelve de color rojo.
+
+Desde el BACKEND se imprime un mensaje en pantalla "UserName and Password required.”.
+
+Este campo puede contener 1 o mas caracteres: alfanuméricos , caracteres especiales, mayúsculas o minúsculas en todas sus combinaciones
+
+Password :
+
+Este campo no debe ser NULL:
+
+Si el campo es NULL:
+
+Desde el FRONTEND no se muestra mensaje PERO el campo se vuelve de color rojo.
+
+Desde el BACKEND se imprime un mensaje en pantalla "UserName and Password required.”.
+
+Este campo debe contener por lo menos un carácter alfabético en mayúscula, un carácter alfabético minúscula, un digito (0-9), un caracter especial y
+debe ser el largo de 8 o mas caracteres.
+
+Si el campo es invalido saldra un mensaje:
+
+Passwords must have at least one non alphanumeric character, one digit ('0'-'9'), one uppercase ('A'-'Z'), one lowercase ('a'-'z'), one special
+character and Password must be eight characters or longer. Especificaciones API: PUT: /BookStore/v1/Books/{ISBN}
+
+Path: ISBN
+
+Body: replaceIsbn
+
+{ "userId": "string", "isbn": "string" } DELETE /BookStore/v1/Book
+
+Body: stringObject
+
+{ "isbn": "string", "userId": "string" } DELETE /BookStore/v1/Books
+
+Body: UserId
+
+{ "userId": "string", "message": "string" } Para validar que se hayan actualizado o eliminado los libros utilizar GET desde el Backend:
+
+GET/Account/v1/User/{UUID}
+
+Path: UserId


### PR DESCRIPTION
las pruebas UI(TC1 , TC2) se han ignorado debido a problemas del sitioWeb,
Los TC restantes pasaron correctamente.
para el método PUT se agrego una precondition adicional de primero eliminar todos los books ya que si no se hacia esto mismo el status daba 400 , y aun así la acción de reemplazar se realizaba correctamente , cosas de demoqa..

![image](https://github.com/upex-galaxy/L1-cypex-demo/assets/124634241/28321088-0edf-408b-b35a-f7fa91af4b49)

