### PR TITLE
Gx3 5270  tools qa elements radio buttons

### DIFF
--- a/coverage/S47/GX3-5270.md
+++ b/coverage/S47/GX3-5270.md
@@ -1,0 +1,59 @@
+# ToolsQA | Elements | Radio Buttons
+
+Descripción
+Como QA aprendiz,
+
+Quiero testear los Radio Buttons
+
+Para practicar hacer este tipo de Escenario de Testing
+
+✅ACCEPTANCE CRITERIA
+
+Cada Radio Buttons (RB) debe tener la siguiente etiqueta respectiva, hay un total de 3:
+
+Yes
+
+Impressive
+
+No
+
+Output:
+
+Por cada vez que se seleccione un RB, debe visualizar el mensaje siguiente:
+
+ “You have selected ” + buttonName
+
+(TechNote: tomar en cuenta la separación)
+
+donde “buttonName” = RB seleccionado
+
+Excepción:
+
+El único RB que no debe ser seleccionado es el “No”
+
+El cursor del mouse no puede seleccionarlo.
+🚩BUSINESS RULES SPEC
+
+Cada Radio Buttons (RB) debe tener la siguiente etiqueta respectiva, hay un total de 3:
+
+Yes
+
+Impressive
+
+No
+
+Output:
+
+Por cada vez que se seleccione un RB, debe visualizar el mensaje siguiente:
+
+ “You have selected ” + buttonName
+
+(TechNote: tomar en cuenta la separación)
+
+donde “buttonName” = RB seleccionado
+
+Excepción:
+
+El único RB que no debe ser seleccionado es el “No”
+
+El cursor del mouse no puede seleccionarlo.

--- a/cypress/e2e/Tests/Elements/GX3-5270_Radio-Button.cy.js
+++ b/cypress/e2e/Tests/Elements/GX3-5270_Radio-Button.cy.js
@@ -27,7 +27,7 @@ describe('GX3-5270 | ToolsQA | Elements | Radio Buttons', () => {
 		cy.get('.text-success').should('have.text', 'Impressive');
 		cy.contains('You have selected Impressive').should('be.visible');
 	});
-	it.only('GX3 5270 | TC6: Validar que Radio Button "No" no puede ser seleccionado', () => {
+	it('GX3 5270 | TC6: Validar que Radio Button "No" no puede ser seleccionado', () => {
 		cy.get('.custom-control-input.disabled').should('be.disabled');
 	});
 });

--- a/cypress/e2e/Tests/Elements/GX3-5270_Radio-Button.cy.js
+++ b/cypress/e2e/Tests/Elements/GX3-5270_Radio-Button.cy.js
@@ -1,0 +1,33 @@
+describe('GX3-5270 | ToolsQA | Elements | Radio Buttons', () => {
+	beforeEach(() => {
+		cy.visit('https://demoqa.com/radio-button');
+	});
+	it('GX3 5270 | TC1: Validar que la pagina carga correctamente.', () => {
+		cy.url().should('include', '/radio-button');
+		cy.get('h1.text-center').should('have.text', 'Radio Button');
+	});
+	it('GX3 5270 | TC2: Validar que los tres botones de radio esten presentes', () => {
+		cy.get('input[type="radio"]').should('have.length', 3);
+		cy.contains('Yes').should('be.visible');
+		cy.contains('Impressive').should('be.visible');
+		cy.contains('No').should('be.visible');
+	});
+	it('GX3 5270 | TC3: Validar que ningun boton este seleccionado por defecto', () => {
+		cy.get('#yesRadio.custom-control-input').should('not.be.checked');
+		cy.get('#impressiveRadio.custom-control-input').should('not.be.checked');
+		cy.get('#noRadio.custom-control-input').should('not.be.checked');
+	});
+	it('GX3 5270 | TC4: Validar seleccionar Radio Button "Yes".', () => {
+		cy.get('label[for="yesRadio"]').click();
+		cy.get('.text-success').should('have.text', 'Yes');
+		cy.contains('You have selected Yes').should('be.visible');
+	});
+	it('GX3 5270 | TC5: Validar seleccionar Radio Button "Impressive".', () => {
+		cy.get('label[for="impressiveRadio"]').click();
+		cy.get('.text-success').should('have.text', 'Impressive');
+		cy.contains('You have selected Impressive').should('be.visible');
+	});
+	it.only('GX3 5270 | TC6: Validar que Radio Button "No" no puede ser seleccionado', () => {
+		cy.get('.custom-control-input.disabled').should('be.disabled');
+	});
+});


### PR DESCRIPTION
# **Nomenclatura del Título del Pull Request**

> "Test(GX3-5270): `add 6 test cases for the Radio Button`"

## Feature to be Test Automated

- `(GX3-5270`: [Radio_Button](https://demoqa.com/radio-button)

## Summary of Changes

> Se realizo la creación de 6 casos de prueba para automatizar los inputs. 
> Para cada acción se realizo una validación

## Test Results Verification

Resultado del Sanity Pipeline triggeado
![image](https://github.com/user-attachments/assets/43756263-e875-497a-acab-34ad9cddd714)


## Git Log

```bash
Commits on Oct 10, 2024
[test: (GX3-5270) add 6 test cases for the Radio Button](https://github.com/upex-galaxy/upex-cypress-demo/commit/e54895009331d9b38c27036b49acded283c26447)

@[Dalfonz](https://github.com/upex-galaxy/upex-cypress-demo/commits?author=Dalfonz)
Dalfonz committed 4 days ago
Commits on Oct 14, 2024
[test: (GX3-5270) add file markdown](https://github.com/upex-galaxy/upex-cypress-demo/commit/a5159c0cf478b4ccfd19cb0d1c087d525bba6c57)

@[Dalfonz](https://github.com/upex-galaxy/upex-cypress-demo/commits?author=Dalfonz)
Dalfonz committed 26 minutes ago
```

## Observations

"ninguna"

## Checklist

- [x] Mi código sigue las pautas de estilo de este proyecto, revisando la nomenclatura usada y corrigiendo cualquier error ortográfico.

- [x] He realizado una revisión doble de mi propio código y he comentado especialmente en áreas difíciles de entender.

- [x] Las pruebas automatizadas nuevas y existentes pasan localmente y he comprobado que mi código funciona sin generar nuevas advertencias (IMPORTANTE)

- [x] He ejecutado el Pipeline de "Sanity Test" específicamente para importar mis Resultados de Prueba a Jira y he comprobado así que mi código de prueba funciona también en CI (IMPORTANTE)

- [x] Confirmo que he considerado agregar documentación nueva al proyecto (en la carpeta `docs/`) en caso de ser necesario. Véase en la descripción del PR si he agregado o no.
