### PR TITLE
Test (GX3-5565) ToolsQA | Elements | Buttons

### DIFF
--- a/.github/workflows/sanity-verogeid-GX3-5565.yml
+++ b/.github/workflows/sanity-verogeid-GX3-5565.yml
@@ -14,7 +14,7 @@ run-name: ${{github.actor}}👨🏻‍🔬 triggered SanityTest in ${{github.ref
 
 on:
   push:
-    branches: ['test/GX3-5552/ToolsQA-Radio-Buttons'] #! Cambia "TuBranchAqui" por el nombre de tu rama de tarea.
+    branches: [ 'test/GX3-5565/ToolsQA-Buttons' ] #! Cambia "TuBranchAqui" por el nombre de tu rama de tarea.
   workflow_dispatch:
 
 
@@ -42,8 +42,8 @@ jobs:
       uses: cypress-io/github-action@v4
       with:
         browser: chrome
-        command: | #todo: GX3-5552-Radio-Buttons.cy.js:
-          bun run test:chrome cypress/e2e/Tests/Elements/GX3-5552-Radio-Buttons.cy.js
+        command: | #todo: GX3-5565-Buttons.cy.js:
+          bun run test:chrome cypress/e2e/Tests/Elements/GX3-5565-Buttons.cy.js
     - name: 📬Generate JUnit/Mocha Report
       if: always()
       run: |
@@ -52,12 +52,13 @@ jobs:
     - name: ✅Import Test Results to Xray
       if: env.XRAY_CLIENT != '' && env.XRAY_SECRET != '' #? Corre este paso si las variables de entorno están definidas
       uses: mikepenz/xray-action@v3
-      with: #OPCIONES PARA IMPORTAR LOS RESULTADOS DE PRUEBA A JIRA XRAY:
+      with:
+        #OPCIONES PARA IMPORTAR LOS RESULTADOS DE PRUEBA A JIRA XRAY:
         username: ${{secrets.XRAY_CLIENT_ID}}
         password: ${{secrets.XRAY_CLIENT_SECRET}}
         testFormat: 'junit' #! NO CAMBIAR
         testPaths: 'cypress/tests_results/junit/chrome_regression_report.xml' #! NO CAMBIAR
-        testExecKey: 'GX3-5552' #todo: EDITAR AQUÍ EL TEST EXECUTION A IMPORTAR LAS PRUEBAS.
+        testExecKey: 'GX3-5565' #todo: EDITAR AQUÍ EL TEST EXECUTION A IMPORTAR LAS PRUEBAS.
         projectKey: 'GX3' #todo: EDITAR EN CASO DE TRABAJAR CON OTRO PROYECTO.
       env:
         XRAY_CLIENT: ${{ secrets.XRAY_CLIENT_SECRET }}

--- a/coverage/S48/GX3-5565.md
+++ b/coverage/S48/GX3-5565.md
@@ -1,0 +1,27 @@
+# ⚡️[Automation] ToolsQA | Elements | Buttons
+
+[GX3-5565](https://upexgalaxy47.atlassian.net/browse/GX3-5565) Created: 10/30/24
+
+**As**  QA learner
+**I want to test** Buttons
+    *- Button double click*
+    *- Button right click*
+    *- Button click*
+**In order to** be able to improve my testing skills for this scenario
+
+```feature
+Feature: ToolsQA | Elements | Buttons
+
+✅ACCEPTANCE CRITERIA
+
+    Button ( Double Click ):
+        IF: *Double Click* button is clicked
+        Then : In the ClickMessage section, a message must be displayed as: ( “You have done a double click” )
+
+    Button ( Right Click ) :
+        IF: *Right Click* button is clicked
+        Then : In the ClickMessage section, a message must be displayed as: ( “You have done a right click” )
+
+    Button ( Click ):
+        IF: *Click* button is clicked
+        Then : In the ClickMessage section, a message must be displayed as: ( “You have done a dynamic click” )

--- a/cypress/e2e/Tests/Elements/GX3-5565-Buttons.cy.js
+++ b/cypress/e2e/Tests/Elements/GX3-5565-Buttons.cy.js
@@ -1,0 +1,90 @@
+describe('US GX3-5565 | ToolsQA | Elements | Buttons', () => {
+	beforeEach('PRC: Abrir la url buttons de ToolsQA', () => {
+		cy.visit('https://demoqa.com/buttons');
+		cy.url().should('contain', 'buttons');
+	});
+
+	it('US # GX3-5565 | TC#01: Validar comportamiento del button "DOUBLE Click" al hacer dblClick', () => {
+		cy.get('button#doubleClickBtn').as('doubleClickBtn');
+
+		cy.get('@doubleClickBtn').should('exist').and('be.enabled').and('be.visible').and('contain.text', 'Double Click Me');
+
+		cy.get('@doubleClickBtn').dblclick();
+
+		cy.get('p[id=doubleClickMessage]').as('doubleClickMessage');
+
+		cy.get('@doubleClickMessage').should('exist').and('be.visible').and('contain.text', 'You have done a double click');
+	});
+
+	it('US # GX3-5565 | TC#02: Validar comportamiento del button "RIGHT Click" al hacer rightClick', () => {
+		cy.get('button#rightClickBtn').as('rightClickBtn');
+
+		cy.get('@rightClickBtn').should('exist').and('be.enabled').and('be.visible').and('contain.text', 'Right Click Me');
+
+		cy.get('@rightClickBtn').rightclick();
+
+		cy.get('p[id=rightClickMessage]').as('rightClickMessage');
+
+		cy.get('@rightClickMessage').should('exist').and('be.visible').and('contain.text', 'You have done a right click');
+	});
+
+	it('US # GX3-5565 | TC#03: Validar comportamiento del button "CLICK" al hacer click', () => {
+		// button#fcmdZ es un randomId. Hay que localizar el botón de otra manera
+		cy.get('button.btn.btn-primary').should('contain.text', 'Click Me').not(':contains("Right")').not(':contains("Double")').as('clickBtn');
+
+		cy.get('@clickBtn').should('exist').and('be.enabled').and('be.visible');
+
+		cy.get('@clickBtn').click();
+
+		cy.get('p[id=dynamicClickMessage]').as('dynamicClickMessage');
+
+		cy.get('@dynamicClickMessage').should('exist').and('be.visible').and('contain.text', 'You have done a dynamic click');
+	});
+
+	it('US # GX3-5565 | TC#04: Validar que NO haga nada el button "DOUBLE Click" con OTRO EVENTO', () => {
+		cy.get('button#doubleClickBtn').as('doubleClickBtn');
+
+		cy.get('@doubleClickBtn').should('exist').and('be.enabled').and('be.visible');
+
+		cy.get('@doubleClickBtn').click();
+
+		cy.get('@doubleClickBtn').rightclick();
+
+		cy.get('p[id=doubleClickMessage]').should('not.exist');
+
+		cy.get('p[id=rightClickMessage]').should('not.exist');
+
+		cy.get('p[id=dynamicClickMessage]').should('not.exist');
+	});
+
+	it('US # GX3-5565 | TC#05: Validar que NO haga nada el button "RIGHT Click" con OTRO EVENTO', () => {
+		cy.get('button#rightClickBtn').as('rightClickBtn');
+		cy.get('@rightClickBtn').should('be.enabled').and('be.visible');
+
+		cy.get('@rightClickBtn').click();
+
+		cy.get('@rightClickBtn').dblclick();
+
+		cy.get('p[id=doubleClickMessage]').should('not.exist');
+
+		cy.get('p[id=rightClickMessage]').should('not.exist');
+
+		cy.get('p[id=dynamicClickMessage]').should('not.exist');
+	});
+
+	it('US # GX3-5565 | TC#06: Validar que NO haga nada el button "CLICK" con OTRO EVENTO', () => {
+		cy.get('button.btn.btn-primary').should('contain.text', 'Click Me').not(':contains("Right")').not(':contains("Double")').as('clickBtn');
+
+		cy.get('@clickBtn').should('be.enabled').and('be.visible');
+
+		cy.get('@clickBtn').rightclick();
+
+		cy.get('@clickBtn').dblclick();
+
+		cy.get('p[id=doubleClickMessage]').should('not.exist');
+
+		cy.get('p[id=rightClickMessage]').should('not.exist');
+
+		// Al hacer doble click estamos haciendo si o si click
+	});
+});


### PR DESCRIPTION
# **Nomenclatura del Título del Pull Request**

> "Test(`GX3-5565`): `ToolsQA | Elements | Buttons`"

## Feature to be Test Automated

- `GX3-5565`: [ToolsQA | Elements | Buttons](https://upexgalaxy47.atlassian.net/browse/GX3-5565)

## Summary of Changes

> Se realizan las pruebas descritas en el TD.
> Además, se incorporan casos de prueba negativos, para asegurar el correcto funcionamiento del conjunto de elementos.
> No se encontraron defectos.

## Test Results Verification

![TD Results GX3-5565](https://github.com/user-attachments/assets/511bdea5-8593-4453-96e5-530ae925cca6)

## Git Log

```bash
commit b3d008b0c16220dfa47ff16e49cfc37272b96925 (HEAD -> test/GX3-5565/ToolsQA-Buttons, origin/test/GX3-5565/ToolsQA-Buttons)
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Fri Nov 29 09:37:57 2024 +0100

    fix (GX3-5565) Fix url references in sanity workflow file
    and renamed it
            renamed:    .github/workflows/sanity-verogeid.yml -> .github/workflows/sanity-verogeid-GX3-5565.yml

commit 87537e43eb06773893c9b2bc2b65d3f65be0446c (remote/test/GX3-5565/ToolsQA-Buttons)
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Wed Nov 27 18:07:45 2024 +0100

    fix (GX3-5565) Restore server copy to local repo

commit b8fb34c6f597741c8db51870e9ad4bda4d1733b0
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Fri Nov 22 10:57:09 2024 +0100

    fix (GX3-5484) Delete unnecesary file json of the branch

commit 17520aeeb67e0a2bbbae21bda21a404cc7ae67e6 
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Mon Nov 18 10:40:07 2024 +0100

    fix (GX3-5565) Find random button without index

commit 182fbe580d3c83d28332f4da6c76e94f1f7f5dee
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Thu Nov 7 00:44:21 2024 +0100

    fix (GX3-5565) Corregido error con within

commit 1bb7816b0e651cbb2d3479827830f5c6716236a5
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Wed Nov 6 21:39:12 2024 +0100

    fix (GX3-5565) eliminado texto introducido por error

commit f8ccacd671e4bc08da3ef29624397d6a1d29a4c6
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Wed Nov 6 16:33:12 2024 +0100

    fix (GX3-5565) Inclusión de alias y within

commit d3bbf0cecfba41ee8877dae95d2010d07ac142a7
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Wed Nov 6 12:52:53 2024 +0100

    fix (GX3-5565) Eliminado el tag div de la localización del botón Click

commit 78b29c1978ede3fd67361565476cf2a83ea99be5
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Wed Nov 6 12:20:25 2024 +0100

    fix (GX3-5565) Eliminados test innecesario e integrados en las pruebas ya existentes. Eliminadas las ramas desactualizadas que se subían a la vez.

commit 2df67862d6e7c7513ad94639da8674b6387b56cc
Merge: 5d8e2f33 ab74a6b6
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Tue Nov 5 09:25:40 2024 +0100

    Merge branch 'QA' of https://github.com/upex-galaxy/upex-cypress-demo into test/GX3-5565/ToolsQA-Buttons

commit 5d8e2f33b1d78ecc1e3bdeb9781971817b99b881 
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Thu Oct 31 14:23:59 2024 +0100

    fix (GX3-5565) Corregido workflow

commit e638b8f5e40fd9eeca1cdb2942608e94f37c10df
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Wed Oct 30 12:46:03 2024 +0100

    test: (GX3-5565) Creación de las pruebas

commit 39c4e3a6d64479a9a8728a47db1229e44e716f27
Author: Diego González Fernández <verogeid@gmail.com>
Date:   Wed Oct 30 10:30:33 2024 +0100

    feature (GX3-5565) Creación de la rama y del md
```

## Observations

> El button "Click Me" tiene un random Id por lo que ha tocado investigar como identificarlo. Se ha utlizado el método not. Ha resultado instructivo, decidiendo en ese momento que el siguiente TD tendría que tener valores random, para practicar.

## Checklist

- [x] Mi código sigue las pautas de estilo de este proyecto, revisando la nomenclatura usada y corregiendo cualquier error ortográfico.

- [x] He realizado una revisión doble de mi propio código y he comentado especialmente en áreas difíciles de entender.

- [x] Las pruebas automatizadas nuevas y existentes pasan localmente y he comprobado que mi código funciona sin generar nuevas advertencias (IMPORTANTE)

- [x] He ejecutado el Pipeline de "Sanity Test" específicamente para importar mis Resultados de Prueba a Jira y he comprobado así que mi código de prueba funciona también en CI (IMPORTANTE)

- [x] Confirmo que he considerado agregar documentación nueva al proyecto (en la carpeta `docs/`) en caso de ser necesario. Véase en la descripción del PR si he agregado o no.
